### PR TITLE
Full-width `.entry-bar-right` when `.entry-bar-left` is empty

### DIFF
--- a/style.css
+++ b/style.css
@@ -884,8 +884,9 @@ article.post { margin-bottom: 60px; }
 .entry-bar.hide-scroll { -webkit-transform: translateY(100%); transform: translateY(100%); }
 
 .entry-bar { background: #fff; border-top: 1px solid #e5e5e5; padding: 0; position: fixed; bottom: 0; left: 0; right: 0; z-index: 999; }
+.entry-bar ul { width: 100%; }
 .entry-bar .entry-bar-left { width: 50%; float: left; }
-.entry-bar .entry-bar-right { width: 50%; float: left; }
+.entry-bar .entry-bar-right { display: flex; }
 .entry-bar .sharrre-container { float: left; min-width: 100%; }
 
 


### PR DESCRIPTION
Hello @AlxMedia,
I've recently installed the Minimer theme on my WordPress blog and I love it.

I've made a small modification to support installations where the "required theme extensions" are not used. I haven't installed any of the proposed extensions, but in fact I don't want to. In my situation, the below links "next" and "previous" only occupy 50% of the total page width.
I've modified the CSS to support both cases, but with 100% width if social links aren't there. Below are screen captures of the mobile view. Desktop view is also supported.

extension | before | after
--- | --- | ---
disabled | ![before, without extension](https://i.ibb.co/KjbXwXc/before-no-extension.png) | ![after, without extension](https://i.ibb.co/Xjdzjz1/after-no-extension.png)
enabled | ![before, with extension](https://i.ibb.co/mHfGp6W/before-with-extension.png) | ![after, with extension](https://i.ibb.co/rZDm94r/after-with-extension.png)